### PR TITLE
Added base path to vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '',
   plugins: [react(), tsconfigPaths()],
   build: {
     // TODO: optimize for production; e.g. use manualChunks


### PR DESCRIPTION
This pull request includes a small change to the `vite.config.ts` file. The change sets the `base` property to an empty string in the Vite configuration.

* [`vite.config.ts`](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR7): Added `base: ''` to the Vite configuration to set the base URL to an empty string.